### PR TITLE
fix: rotating keys buffer length

### DIFF
--- a/src/auth/rotating-credential.test.ts
+++ b/src/auth/rotating-credential.test.ts
@@ -5,7 +5,7 @@ describe("rotating-credential", () => {
     const credential = new RotatingCredential(["key1", "key2"]);
     const key = await credential.sign("some string");
 
-    expect(key).toEqual("o7JXe_dO9VlA7ofGeu_IeV9iFK74t6SNdLt5XIADMeVFrJxEHpVMuD5HSU6kS9iCdApPxowqWGYZmRIUcjxLTg");
+    expect(key).toEqual("pRUtdYSFwPukug4oJuql5qtl9Vc");
     expect(await credential.verify("some string", key)).toBe(true);
     expect(await credential.verify("some string", "wat")).toBe(false);
     expect(await credential.verify("some", key)).toBe(false);

--- a/src/auth/rotating-credential.ts
+++ b/src/auth/rotating-credential.ts
@@ -1,7 +1,7 @@
 import { arrayBufferToBase64, stringToArrayBuffer } from "./jwt/utils";
 
 export class RotatingCredential {
-  private digestAlgorithm = "SHA-512";
+  private digestAlgorithm = "SHA-1";
 
   constructor(private keys: string[]) {}
 
@@ -9,7 +9,7 @@ export class RotatingCredential {
     return {
       name: "HMAC",
       hash: {
-        name: "SHA-512",
+        name: "SHA-1",
       },
       length,
     };
@@ -18,16 +18,18 @@ export class RotatingCredential {
   private async signKey(data: string, keyValue: string) {
     const keyBuffer = stringToArrayBuffer(keyValue);
     const dataBuffer = stringToArrayBuffer(data);
+    const keyBitLength = keyBuffer.byteLength * 8;
     const digest = await crypto.subtle.digest(this.digestAlgorithm, dataBuffer);
     const key = await crypto.subtle.importKey(
       "raw",
       keyBuffer,
-      this.getSignAlgorithm(digest.byteLength),
+      this.getSignAlgorithm(keyBitLength),
       false,
       ["sign"]
     );
+
     const signed = await crypto.subtle.sign(
-      this.getSignAlgorithm(digest.byteLength),
+      this.getSignAlgorithm(keyBitLength),
       key,
       digest
     );


### PR DESCRIPTION
Fixed incorrect rotating keys buffer length which caused error on Vercel Edge Runtime: 

https://github.com/ensite-in/next-firebase-auth-edge/issues/6